### PR TITLE
feat: expose open cash drawer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,10 +533,11 @@ set blob of the line.
 #### printQRCode(String content, int size, int correctionLevel, int leftPadding)
 
 prints the qrcode.
-content: string text value
-size: integer size of qr code.
-correctionLevel: L:1, M:0, Q:3, H:2
-leftPadding: integer value for left padding of qrcode
+
+- `content`: string text value
+- `size`: integer size of qr code.
+- `correctionLevel`: L:1, M:0, Q:3, H:2
+- `leftPadding`: integer value for left padding of qrcode
 
 Example usage:
 
@@ -571,6 +572,20 @@ const printBarcode = async (
     2
   );
 };
+```
+
+#### openDrawer(int nMode, int nTime1, int nTime2)
+
+Kick the cash drawer.
+
+- `nMode`: DK connector pin to output control signals (0 for Pin2/drawer1 or 1 for Pin5/drawer2)
+- `nTime1`: ON time of the drawer kick signal.
+- `nTime2`: OFF time of the drawer kick signal (time before the next ON signal can be received).
+
+Example usage:
+
+```javascript
+await BluetoothEscposPrinter.openDrawer(0, 25, 250);
 ```
 
 ### Demos of printing a receipt

--- a/android/src/main/java/cn/jystudio/bluetooth/escpos/RNBluetoothEscposPrinterModule.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/escpos/RNBluetoothEscposPrinterModule.java
@@ -440,6 +440,15 @@ public class RNBluetoothEscposPrinterModule extends ReactContextBaseJavaModule
         sendDataByte(command);
     }
 
+    @ReactMethod
+    public void openDrawer(int nMode, int nTime1, int nTime2, final Promise promise) {
+        byte[] command = PrinterCommand.POS_Set_Cashbox(nMode, nTime1, nTime2);
+        if (sendDataByte(command)) {
+            promise.resolve(null);
+        } else {
+            promise.reject("COMMAND_NOT_SEND");
+        }
+    }
    
     private boolean sendDataByte(byte[] data) {
         if (data==null || mService.getState() != BluetoothService.STATE_CONNECTED) {

--- a/android/src/main/java/cn/jystudio/bluetooth/escpos/command/sdk/Command.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/escpos/command/sdk/Command.java
@@ -125,7 +125,7 @@ public class Command {
 	public static byte[] DLE_DC4 = new byte[] {DLE, DC4, 0x00, 0x00, 0x00 };
 	
 	//标准弹钱箱指令
-	public static byte[] ESC_p = new byte[] {ESC, 'F', 0x00, 0x00, 0x00 };
+	public static byte[] ESC_p = new byte[] {ESC, 'p', 0x00, 0x00, 0x00 };
 	
 	/**
 	 * 条码设置指令


### PR DESCRIPTION
cherry-picked from [b1a548f608d1b03e4d9be51cb1ac68117001f048](https://github.com/januslo/react-native-bluetooth-escpos-printer/commit/b1a548f608d1b03e4d9be51cb1ac68117001f048)